### PR TITLE
Add NPC worldIndex to NPC update packets

### DIFF
--- a/src/main/java/org/runejs/client/media/renderable/actor/Npc.java
+++ b/src/main/java/org/runejs/client/media/renderable/actor/Npc.java
@@ -11,49 +11,117 @@ public class Npc extends Actor {
     public ActorDefinition actorDefinition;
 
     public static void parseNpcUpdateMasks(PacketBuffer buffer) {
-        for(int i = 0; i < actorUpdatingIndex; i++) {
-            int npcIndex = Player.actorUpdatingIndices[i];
-            Npc npc = Player.npcs[npcIndex];
+        for (int i = 0; i < actorUpdatingIndex; i++) {
+            int npcIndex = -1;
+            Npc npc = null;
+
+            boolean alreadyGotWorldIndex = false;
+
             int mask = buffer.getUnsignedByte();
-            if((0x1 & mask) != 0) {
+            if ((0x1 & mask) != 0) {
                 int i_3_ = buffer.getUnsignedByte();
                 int i_4_ = buffer.getUnsignedByte();
+                int remainingHitpoints = buffer.getUnsignedByte();
+                int maximumHitpoints = buffer.getUnsignedByte();
+
+                // the NPC's worldIndex bytes won't be included if already
+                // sent earlier
+                if (!alreadyGotWorldIndex) {
+                    npcIndex = buffer.getUnsignedShortBE();
+                    npc = Player.npcs[npcIndex];
+                    alreadyGotWorldIndex = true;
+                }
+
                 npc.method785(i_4_, MovedStatics.pulseCycle, i_3_);
                 npc.anInt3139 = MovedStatics.pulseCycle + 300;
-                npc.remainingHitpoints = buffer.getUnsignedByte();
-                npc.maximumHitpoints = buffer.getUnsignedByte();
+                npc.remainingHitpoints = remainingHitpoints;
+                npc.maximumHitpoints = maximumHitpoints;
             }
-            if((0x20 & mask) != 0) {
-                npc.graphicId = buffer.getUnsignedShortLE();
+            if ((0x20 & mask) != 0) {
+                int graphicId = buffer.getUnsignedShortLE();
                 int i_5_ = buffer.getIntBE();
+
+                // the NPC's worldIndex bytes won't be included if already
+                // sent earlier
+                if (!alreadyGotWorldIndex) {
+                    npcIndex = buffer.getUnsignedShortBE();
+                    npc = Player.npcs[npcIndex];
+                    alreadyGotWorldIndex = true;
+                }
+                npc.graphicId = graphicId;
                 npc.anInt3129 = 0;
                 npc.graphicDelay = MovedStatics.pulseCycle + (0xffff & i_5_);
                 npc.graphicHeight = i_5_ >> 16;
                 npc.anInt3140 = 0;
-                if(npc.graphicDelay > MovedStatics.pulseCycle)
+                if (npc.graphicDelay > MovedStatics.pulseCycle)
                     npc.anInt3140 = -1;
-                if(npc.graphicId == 65535)
+                if (npc.graphicId == 65535)
                     npc.graphicId = -1;
             }
-            if((mask & 0x4) != 0) {
-                npc.facingActorIndex = buffer.getUnsignedShortBE();
-                if(npc.facingActorIndex == 65535)
+            if ((mask & 0x4) != 0) {
+                int facingActorIndex = buffer.getUnsignedShortBE();
+
+                // the NPC's worldIndex bytes won't be included if already
+                // sent earlier
+                if (!alreadyGotWorldIndex) {
+                    npcIndex = buffer.getUnsignedShortBE();
+                    npc = Player.npcs[npcIndex];
+                    alreadyGotWorldIndex = true;
+                }
+
+                npc.facingActorIndex = facingActorIndex;
+
+                if (npc.facingActorIndex == 65535)
                     npc.facingActorIndex = -1;
             }
-            if((0x2 & mask) != 0) {
+            if ((0x2 & mask) != 0) {
                 int i_6_ = buffer.getUnsignedByte();
                 int i_7_ = buffer.getUnsignedByte();
+
+                int remainingHitpoints = buffer.getUnsignedByte();
+                int maximumHitpoints = buffer.getUnsignedByte();
+
+                // the NPC's worldIndex bytes won't be included if already
+                // sent earlier
+                if (!alreadyGotWorldIndex) {
+                    npcIndex = buffer.getUnsignedShortBE();
+                    npc = Player.npcs[npcIndex];
+                    alreadyGotWorldIndex = true;
+                }
+
                 npc.method785(i_7_, MovedStatics.pulseCycle, i_6_);
                 npc.anInt3139 = MovedStatics.pulseCycle + 300;
-                npc.remainingHitpoints = buffer.getUnsignedByte();
-                npc.maximumHitpoints = buffer.getUnsignedByte();
+
+                npc.remainingHitpoints = remainingHitpoints;
+                npc.maximumHitpoints = maximumHitpoints;
             }
-            if((0x40 & mask) != 0) {
-                npc.forcedChatMessage = buffer.getString();
+            if ((0x40 & mask) != 0) {
+                String forcedChatMessage = buffer.getString();
+
+                // the NPC's worldIndex bytes won't be included if already
+                // sent earlier
+                if (!alreadyGotWorldIndex) {
+                    npcIndex = buffer.getUnsignedShortBE();
+                    npc = Player.npcs[npcIndex];
+                    alreadyGotWorldIndex = true;
+                }
+
+                npc.forcedChatMessage = forcedChatMessage;
+
                 npc.chatTimer = 100;
             }
-            if((mask & 0x80) != 0) {
-                npc.actorDefinition = ActorDefinition.getDefinition(buffer.getUnsignedShortBE());
+            if ((mask & 0x80) != 0) {
+                int actorDefinition = buffer.getUnsignedShortBE();
+
+                // the NPC's worldIndex bytes won't be included if already
+                // sent earlier
+                if (!alreadyGotWorldIndex) {
+                    npcIndex = buffer.getUnsignedShortBE();
+                    npc = Player.npcs[npcIndex];
+                    alreadyGotWorldIndex = true;
+                }
+
+                npc.actorDefinition = ActorDefinition.getDefinition(actorDefinition);
                 npc.anInt3083 = npc.actorDefinition.rotateRightAnimation;
                 npc.anInt3113 = npc.actorDefinition.degreesToTurn;
                 npc.turnRightAnimationId = npc.actorDefinition.rotate90RightAnimation;
@@ -64,26 +132,50 @@ public class Npc extends Actor {
                 npc.turnLeftAnimationId = npc.actorDefinition.rotate90LeftAnimation;
                 npc.turnAroundAnimationId = npc.actorDefinition.rotate180Animation;
             }
-            if((mask & 0x8) != 0) {
-                npc.facePositionX = buffer.getUnsignedShortBE();
-                npc.facePositionY = buffer.getUnsignedShortLE();
+            if ((mask & 0x8) != 0) {
+                int facePositionX = buffer.getUnsignedShortBE();
+                int facePositionY = buffer.getUnsignedShortLE();
+
+                // the NPC's worldIndex bytes won't be included if already
+                // sent earlier
+                if (!alreadyGotWorldIndex) {
+                    npcIndex = buffer.getUnsignedShortBE();
+                    npc = Player.npcs[npcIndex];
+                    alreadyGotWorldIndex = true;
+                }
+
+                npc.facePositionX = facePositionX;
+                npc.facePositionY = facePositionY;
             }
-            if((0x10 & mask) != 0) {
+            if ((0x10 & mask) != 0) {
                 int animationId = buffer.getUnsignedShortBE();
-                if(animationId == 65535)
-                    animationId = -1;
                 int animationDelay = buffer.getUnsignedByte();
-                if(animationId == npc.playingAnimation && animationId != -1) {
+
+                // the NPC's worldIndex bytes won't be included if already
+                // sent earlier
+                if (!alreadyGotWorldIndex) {
+                    npcIndex = buffer.getUnsignedShortBE();
+                    npc = Player.npcs[npcIndex];
+                    alreadyGotWorldIndex = true;
+                }
+
+                if (animationId == 65535) {
+                    animationId = -1;
+                }
+
+                if (animationId == npc.playingAnimation && animationId != -1) {
                     int i_10_ = AnimationSequence.getAnimationSequence(animationId).replyMode;
-                    if(i_10_ == 1) {
+                    if (i_10_ == 1) {
                         npc.anInt3115 = 0;
                         npc.anInt3095 = 0;
                         npc.anInt3104 = 0;
                         npc.playingAnimationDelay = animationDelay;
                     }
-                    if(i_10_ == 2)
+                    if (i_10_ == 2)
                         npc.anInt3095 = 0;
-                } else if(animationId == -1 || npc.playingAnimation == -1 || AnimationSequence.getAnimationSequence(animationId).forcedPriority >= AnimationSequence.getAnimationSequence(npc.playingAnimation).forcedPriority) {
+                } else if (animationId == -1 || npc.playingAnimation == -1
+                        || AnimationSequence.getAnimationSequence(animationId).forcedPriority >= AnimationSequence
+                                .getAnimationSequence(npc.playingAnimation).forcedPriority) {
                     npc.playingAnimation = animationId;
                     npc.anInt3115 = 0;
                     npc.playingAnimationDelay = animationDelay;

--- a/src/main/java/org/runejs/client/message/handler/rs435/updating/UpdateNPCsMessageHandler.java
+++ b/src/main/java/org/runejs/client/message/handler/rs435/updating/UpdateNPCsMessageHandler.java
@@ -24,9 +24,9 @@ public class UpdateNPCsMessageHandler implements MessageHandler<UpdateNPCsInboun
 
         Npc.parseNpcUpdateMasks(message.appearanceUpdates);
 
-        for(int i = 0; i < MovedStatics.deregisterActorCount; i++) {
+        for (int i = 0; i < MovedStatics.deregisterActorCount; i++) {
             int trackedNpcIndex = Player.deregisterActorIndices[i];
-            if(MovedStatics.pulseCycle != Player.npcs[trackedNpcIndex].anInt3134) {
+            if (Player.npcs[trackedNpcIndex] != null && MovedStatics.pulseCycle != Player.npcs[trackedNpcIndex].anInt3134) {
                 Player.npcs[trackedNpcIndex].actorDefinition = null;
                 Player.npcs[trackedNpcIndex] = null;
             }


### PR DESCRIPTION
NPC chat messages and health bars (and possibly other things) currently seem to only show on the first NPC in the client's list of tracked NPC's within player view. This PR fixes that:

- Updates NPC update packet handling to include a new `worldIndex` byte pair

Because this changes the packet structure, older clients won't work after this change if they're using the my code in <https://github.com/runejs/server/pull/433>.

Code quality note: If there are any suggestions on a good way to refactor the lines of code that I repeated multiple times in `src/main/java/org/runejs/client/media/renderable/actor/Npc.java`, please feel free to suggest it.

_See accompanying PR for the client: <https://github.com/runejs/server/pull/433>_

---

edit: previously I coupled a few other changes into this PR, but since this is probably an (understandably) undesirable change, I'm going to remove the other changes into other future PRs